### PR TITLE
Added a log, made app spec consistent with interface.

### DIFF
--- a/app_specs/MSA.json
+++ b/app_specs/MSA.json
@@ -5,6 +5,33 @@
   "description": "Compute the multiple sequence alignment and analyze SNP/variance.",
   "parameters": [
     {
+      "id": "input_status",
+      "allow_multiple": false,
+      "label": "The input status.",
+      "required": 0,
+      "default": "",
+      "desc": "Indicates whether the input is already aligned.",
+      "type": "enum",
+      "enum": [
+        "unaligned",
+        "aligned"
+      ]
+    },
+    {
+      "id": "input_type",
+      "allow_multiple": false,
+      "label": "The type of input selected.",
+      "required": 0,
+      "default": "",
+      "desc": "Selects a type of input file or data to be given to an aligner.",
+      "type": "enum",
+      "enum": [
+        "input_group",
+        "input_fasta",
+        "input_sequence"
+      ]
+    },
+    {
       "id": "fasta_files",
       "type": "group",
       "allow_multiple": true,

--- a/scripts/convert_seq_files.py
+++ b/scripts/convert_seq_files.py
@@ -38,6 +38,7 @@ def convert_file(in_file, out_file_prefix, in_format=INFORMAT, molecule_type=Non
             ),
         )
         p.start()
+        p_list.append(p)
     for p in p_list:
         p.join()
         count += 1

--- a/scripts/snp_analysis_figure.py
+++ b/scripts/snp_analysis_figure.py
@@ -34,7 +34,7 @@ def get_figures(table_location, output_prefix, fig_type="entropy"):
     fig1.tight_layout()
     out_str = "{}.{}.".format(output_prefix, "entropy")
     plt.savefig(out_str + "svg", format="svg")
-    plt.savefig(out_str + "png", format="png")
+    # plt.savefig(out_str + "png", format="png") # Doesn't produce as many bars as svg.
     plt.close()
     # fig2, ax2 = plt.subplots()
     # color = "tab:red"

--- a/service-scripts/App-MSA.pl
+++ b/service-scripts/App-MSA.pl
@@ -236,13 +236,14 @@ sub process_fasta
     elsif ($recipe eq "muscle") {
         # An aln file only displayed 4 out of 8 sequences in MView and JalView for some reason. I could not find anything wrong with the format. Removing clustal w format.
     	print STDOUT "Running MUSCLE.\n";
-        open(MUSCLE_LOG, '>', "$work_dir/muscle.job.log");
         my @muscle_version = ("muscle", "-version");
-        run_cmd(\@muscle_version);
-        run(\@muscle_version, ">", MUSCLE_LOG);
         my @muscle_cmd =  ("muscle", "-quiet", "-in", "$work_dir/input.fasta", "-fastaout", "$work_dir/output.afa"); # , "-clwstrict", "-clwout", "$work_dir/$prefix.aln");
         my $string_cmd = join(" ", @muscle_cmd);
+        run_cmd(\@muscle_version);
+        run(\@muscle_version, "1>>", "$work_dir/muscle.job.log");
+        open(MUSCLE_LOG, '>>', "$work_dir/muscle.job.log") or die $!;
         print MUSCLE_LOG "$string_cmd\n";
+        close(MUSCLE_LOG) or die $!;
         print STDOUT "$string_cmd\n";
         run_cmd(\@muscle_cmd);
         print STDOUT "Finished MUSCLE.\n";
@@ -285,15 +286,16 @@ sub process_fasta
     }
     elsif ($recipe eq "mafft") {
         print STDOUT "Running mafft.\n";
-        open(MAFFT_LOG, '>', "$work_dir/mafft.job.log");
-        my @mafft_version = ("mafft", "--version");
-        run_cmd(\@mafft_version);
-        run(\@mafft_version, "2>", MAFFT_LOG);
         my @mafft_cmd = ("mafft", "--auto", "--preservecase", "$work_dir/input.fasta");
         my $string_cmd = join(" ", @mafft_cmd);
+        my @mafft_version = ("mafft", "--version");
+        run(\@mafft_version, "2>>", "$work_dir/mafft.job.log");
+        run_cmd(\@mafft_version);
+        open(MAFFT_LOG, '>>', "$work_dir/mafft.job.log") or die $!;
         print MAFFT_LOG "$string_cmd\n";
+        close(MAFFT_LOG) or die $!;
         print STDERR "$string_cmd\n";
-        my $ok = run(\@mafft_cmd, "1>", "$work_dir/output.afa", "2>", MAFFT_LOG);
+        my $ok = run(\@mafft_cmd, "1>", "$work_dir/output.afa", "2>>", "$work_dir/mafft.job.log");
         if (!$ok) {
             die "Mafft command failed.\n";
         }

--- a/service-scripts/App-MSA.pl
+++ b/service-scripts/App-MSA.pl
@@ -235,9 +235,14 @@ sub process_fasta
     }
     elsif ($recipe eq "muscle") {
         # An aln file only displayed 4 out of 8 sequences in MView and JalView for some reason. I could not find anything wrong with the format. Removing clustal w format.
-    	my @muscle_cmd =  ("muscle", "-quiet", "-in", "$work_dir/input.fasta", "-fastaout", "$work_dir/output.afa"); # , "-clwstrict", "-clwout", "$work_dir/$prefix.aln");
+    	print STDOUT "Running MUSCLE.\n";
+        open(MUSCLE_LOG, '>', "$work_dir/muscle.job.log");
+        my @muscle_version = ("muscle", "-version");
+        run_cmd(\@muscle_version);
+        run(\@muscle_version, ">", MUSCLE_LOG);
+        my @muscle_cmd =  ("muscle", "-quiet", "-in", "$work_dir/input.fasta", "-fastaout", "$work_dir/output.afa"); # , "-clwstrict", "-clwout", "$work_dir/$prefix.aln");
         my $string_cmd = join(" ", @muscle_cmd);
-        print STDOUT "Running MUSCLE.\n";
+        print MUSCLE_LOG "$string_cmd\n";
         print STDOUT "$string_cmd\n";
         run_cmd(\@muscle_cmd);
         print STDOUT "Finished MUSCLE.\n";
@@ -279,11 +284,16 @@ sub process_fasta
         close(OUTF) or die $!;
     }
     elsif ($recipe eq "mafft") {
+        print STDOUT "Running mafft.\n";
+        open(MAFFT_LOG, '>', "$work_dir/mafft.job.log");
+        my @mafft_version = ("mafft", "--version");
+        run_cmd(\@mafft_version);
+        run(\@mafft_version, "2>", MAFFT_LOG);
         my @mafft_cmd = ("mafft", "--auto", "--preservecase", "$work_dir/input.fasta");
         my $string_cmd = join(" ", @mafft_cmd);
-        print STDOUT "Running mafft.\n";
-        print STDOUT "$string_cmd\n";
-        my $ok = run(\@mafft_cmd, ">", "$work_dir/output.afa");
+        print MAFFT_LOG "$string_cmd\n";
+        print STDERR "$string_cmd\n";
+        my $ok = run(\@mafft_cmd, "1>", "$work_dir/output.afa", "2>", MAFFT_LOG);
         if (!$ok) {
             die "Mafft command failed.\n";
         }
@@ -339,6 +349,7 @@ sub process_fasta
         [qr/\.afa$/, $out_type],
         [qr/\.xmfa$/, "txt"],
         [qr/\.mauve.log$/, "txt"],
+        [qr/\.job.log$/, "txt"],
         [qr/\.aln$/, "txt"],
         [qr/\.consensus\.fasta$/, "txt"],
         [qr/\.tsv$/, "tsv"],

--- a/tests/mat_pep.json
+++ b/tests/mat_pep.json
@@ -1,0 +1,13 @@
+{
+    "input_status": "unaligned",
+    "input_type": "input_group",
+    "alphabet": "protein",
+    "aligner": "Mafft",
+    "user_genomes_alignment": "",
+    "output_path": "/jsporter@patricbrc.org/home/MSA",
+    "output_file": "mat_pep",
+    "fasta_keyboard_input": "",
+    "feature_groups": [
+        "/jsporter@patricbrc.org/home/Feature Groups/mat_pep_cd"
+    ]
+}


### PR DESCRIPTION
1. Adds a log for giving the version and commands for mafft and muscle. Fixes https://github.com/BV-BRC/issues/issues/156
2. Fixes a parallelization issue with file conversion. Now gives a correct count. Joins all processes.
3. Removes the PNG file. Fixes https://github.com/BV-BRC/issues/issues/161
4. Adds a test case for downloading natural peptides.